### PR TITLE
Fix Processor.load() test

### DIFF
--- a/src/processor_test.rs
+++ b/src/processor_test.rs
@@ -27,7 +27,7 @@ fn test_initial_state() {
 #[test]
 fn test_load_data() {
     let mut processor = Processor::new();
-    processor.load(vec![1, 2, 3]);
+    processor.load(&[1, 2, 3]);
     assert_eq!(processor.ram[0x200], 1);
     assert_eq!(processor.ram[0x201], 2);
     assert_eq!(processor.ram[0x202], 3);


### PR DESCRIPTION
The test for Processor.load fails to compile due to type mismatch:
```
 *  Executing task: cargo test --package chip8 --bin chip8 -- processor::processor_test --nocapture 

   Compiling chip8 v0.1.0 (/home/user/chip8-rust)
error[E0308]: mismatched types
  --> src/./processor_test.rs:30:20
   |
30 |     processor.load(vec![1, 2, 3]);
   |               ---- ^^^^^^^^^^^^^ expected `&[u8]`, found struct `Vec`
   |               |
   |               arguments to this function are incorrect
   |
   = note: expected reference `&[u8]`
                 found struct `Vec<{integer}>`
note: associated function defined here
  --> src/processor.rs:74:12
   |
74 |     pub fn load(&mut self, data: &[u8]) {
   |            ^^^^ ---------  -----------
   = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)

For more information about this error, try `rustc --explain E0308`.
error: could not compile `chip8` due to previous error
```

This issue is fixed by passing an array reference instead of a vector.